### PR TITLE
Prevent assumed tid translation [Fix #5]

### DIFF
--- a/brunel/src/main.c
+++ b/brunel/src/main.c
@@ -98,7 +98,6 @@ int* build_translation_file(const char* trans_name, bam_hdr_t* file_header, bam_
     
     while (!feof(trans_file) && !ferror(trans_file) && counter > 0) {
         getline(&linepointer, &read, trans_file);
-        
         char* sep = linepointer;
         strsep(&sep, "\t");
         if (sep == NULL) break;
@@ -111,13 +110,16 @@ int* build_translation_file(const char* trans_name, bam_hdr_t* file_header, bam_
             char* item = file_header->target_name[i];
             if (!strcmp(item,linepointer)) { break; }
         }
-        int j = 0;
-        for ( ; j < replace_entries; j++ ) {
-            char* item = replace_header->target_name[j];
-            if (!strcmp(item,sep)) { break; }
+
+        if(i < file_entries) {
+            // A tid requires replacement
+            int j = 0;
+            for ( ; j < replace_entries; j++ ) {
+                char* item = replace_header->target_name[j];
+                if (!strcmp(item,sep)) { break; }
+            }
+            trans[i] = j;
         }
-        
-        trans[i] = j;
         counter--;
     }
     free(linepointer);


### PR DESCRIPTION
When iterating over an input file to search for tids that may
require translation, if the end of the file is reached with no
matches, `i` is equal to the number of `file_entries`.

It appears an assumption that at least one translation will be
required and `trans[i] = j` is executed even in this case.
As `trans` is only equal to the length of `file_entries - 1`,
updating the contents of `trans` outside of the array is an
invalid operation and appears to cause a memory error that
prevents the `linepointer` buffer used with `getline` to be
free'd safely.

I check here whether `i < file_entries`, _i.e._, a match was
found, only then is the 'j-loop' executed and `trans` updated.
Note here I make the assumption that the correct `j` will be
found (and so don't check `j < replace_entries`).
